### PR TITLE
Adds check to only parse files with a .json extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,8 @@ module.exports = function(url, prev, done) {
   done = end(done);
   if (!url) return done(null);
 
-  const parts = url.split('/');
-  const name = path.basename(parts.pop(), '.json');
+  if (path.extname(url) !== '.json') return done(null);
+  const name = path.basename(url, '.json')
   const cwd = process.cwd();
 
 


### PR DESCRIPTION
When adding this importer into a larger build, I was getting syntax errors when trying to compile, and it was because I was using `@import` in my Sass pointing to URLs with the `.css` extension included (to be inlined later via PostCSS). After doing some testing in a small, isolated project, I found that `json-importer` was trying to parse `.css` files (or any file with an extension - the check to see if a file actually exists (https://github.com/sasstools/json-importer/blob/master/index.js#L47) is neat, because it allows extension-less Sass files to pass through the importer, but all files with extensions get processed).

This PR adds a check on the `extname` of each URL passing through the importer, and only processes files that have a `.json` extension.

Note: I tried to create a test for this situation but couldn't get it to work. I tried using the Sass function `variable-exists` in an `@if` statement to ensure that the generated Sass map with the variables actually exists before writing out the `inspect()` call, but I'm not familiar with the `output { }` and `contents:` syntax, and so I ran into syntax errors. I'm not sure how you could ensure that the module actually tries to parse some Sass content with a real `@import "vendor.css"` line, instead of somehow short-circuiting the test, but perhaps you do, @xzyfer :)